### PR TITLE
Validate if `thread.backtrace` is not nil

### DIFF
--- a/lib/sigdump.rb
+++ b/lib/sigdump.rb
@@ -49,9 +49,11 @@ module Sigdump
     end
 
     io.write "  Thread #{thread} status=#{status} priority=#{thread.priority}\n"
-    thread.backtrace.each {|bt|
-      io.write "      #{bt}\n"
-    }
+    if thread.backtrace
+      thread.backtrace.each {|bt|
+        io.write "      #{bt}\n"
+      }
+    end
 
     io.flush
     nil


### PR DESCRIPTION
Becuase in MRI `Thread#backtrace` returns Array or nil,
check if `thread.backtrace` is not nil to avoid
`NoMethodError: undefined method`each' for nil:NilClass`

ref: https://github.com/ruby/ruby/blob/v2_3_1/vm_backtrace.c#L894-L895
