### PR TITLE
Fix default dump file permission : 0666 => 0600

### DIFF
--- a/lib/sigdump.rb
+++ b/lib/sigdump.rb
@@ -1,5 +1,6 @@
 module Sigdump
   VERSION = "0.2.4"
+  FILE_PERMISSION = 0600
 
   def self.setup(signal=ENV['SIGDUMP_SIGNAL'] || 'SIGCONT', path=ENV['SIGDUMP_PATH'])
     Kernel.trap(signal) do
@@ -135,7 +136,7 @@ module Sigdump
     case path
     when nil, ""
       path = "/tmp/sigdump-#{Process.pid}.log"
-      File.open(path, "a", &block)
+      File.open(path, "a", FILE_PERMISSION, &block)
     when IO
       yield path
     when "-"
@@ -143,7 +144,7 @@ module Sigdump
     when "+"
       yield STDERR
     else
-      File.open(path, "a", &block)
+      File.open(path, "a", FILE_PERMISSION, &block)
     end
   end
   private_class_method :_open_dump_path


### PR DESCRIPTION
Currently, the default dump file permission is 0666. But there will be
no reason to let other users to read or modify dump files.

An attacker could inject some malicious escape sequences into a file,
which may be executed on a victim’s terminal emulator (Not Critical).