### PR TITLE
Add support for printing a thread's name

### DIFF
--- a/lib/sigdump.rb
+++ b/lib/sigdump.rb
@@ -48,7 +48,7 @@ module Sigdump
       status = "error"
     end
 
-    io.write "  Thread #{thread} status=#{status} priority=#{thread.priority}\n"
+    io.write "  Thread #{thread}#{thread.respond_to?(:name) && thread.name ? " name=#{thread.name}" : ""} status=#{status} priority=#{thread.priority}\n"
     if thread.backtrace
       thread.backtrace.each {|bt|
         io.write "      #{bt}\n"


### PR DESCRIPTION
Available since Ruby 2.3.  Is a noop on earlier Rubies.