### PR TITLE
Avoid to write linked path

### DIFF
--- a/lib/sigdump.rb
+++ b/lib/sigdump.rb
@@ -148,7 +148,7 @@ module Sigdump
     case path
     when nil, ""
       path = _avoid_linked_path_if_needed("/tmp/sigdump-#{Process.pid}.log")
-      File.open(path, "a", &block)
+      File.open(path, "a", 0644, &block)
     when IO
       yield path
     when "-"
@@ -156,7 +156,7 @@ module Sigdump
     when "+"
       yield STDERR
     else
-      File.open(_avoid_linked_path_if_needed(path), "a", &block)
+      File.open(_avoid_linked_path_if_needed(path), "a", 0644, &block)
     end
   end
   private_class_method :_open_dump_path


### PR DESCRIPTION
Currently, sigdump uses predictable path to write object dump. 
But, in some circumstances, this implementation makes a vulnerability for dangling symlink attack.
And also, `Kernel.open` should use `0644` instead of `0666`(wolrd-writable permission).
This will be also vulnerability part of dangling symlink attack.